### PR TITLE
Remove test executable lines from CMakeLists.txt

### DIFF
--- a/raw2dng/CMakeLists.txt
+++ b/raw2dng/CMakeLists.txt
@@ -82,8 +82,6 @@ TARGET_LINK_LIBRARIES(raw2dng dng
                               ${LIBRAW_LIBRARIES}
                               ${EXIV2_LIBRARIES})
 
-ADD_EXECUTABLE( test ${CMAKE_CURRENT_SOURCE_DIR}/test.cpp)
-TARGET_LINK_LIBRARIES (test ${EXIV2_LIBRARIES})
 
 # add the install targets
 INSTALL(TARGETS raw2dng DESTINATION bin)


### PR DESCRIPTION
Removed reference to some test lines in CMakeLists.txt, which prevented cmake to accomplish its task.
